### PR TITLE
fix: service for filling in statistics of selected ads has been changed

### DIFF
--- a/src/main/java/ru/avitoAnalytics/AvitoAnalyticsBot/controller/TelegramBot.java
+++ b/src/main/java/ru/avitoAnalytics/AvitoAnalyticsBot/controller/TelegramBot.java
@@ -2,7 +2,6 @@ package ru.avitoAnalytics.AvitoAnalyticsBot.controller;
 
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.bots.TelegramLongPollingBot;
 import org.telegram.telegrambots.meta.api.methods.commands.SetMyCommands;
@@ -18,13 +17,11 @@ import ru.avitoAnalytics.AvitoAnalyticsBot.configuration.BotConfig;
 import ru.avitoAnalytics.AvitoAnalyticsBot.entity.User;
 import ru.avitoAnalytics.AvitoAnalyticsBot.service.SelectedAdsStatisticService;
 import ru.avitoAnalytics.AvitoAnalyticsBot.service.UserService;
-import ru.avitoAnalytics.AvitoAnalyticsBot.service.impl.SelectedAdsStatisticServiceImpl;
 import ru.avitoAnalytics.AvitoAnalyticsBot.util.PatternMap;
 
-import java.time.DayOfWeek;
-import java.time.LocalDate;
-import java.time.format.TextStyle;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Component

--- a/src/main/java/ru/avitoAnalytics/AvitoAnalyticsBot/service/impl/GoogleSheetsServiceImpl.java
+++ b/src/main/java/ru/avitoAnalytics/AvitoAnalyticsBot/service/impl/GoogleSheetsServiceImpl.java
@@ -9,10 +9,8 @@ import com.google.api.services.sheets.v4.Sheets.Spreadsheets.SheetsOperations.Co
 import com.google.api.services.sheets.v4.SheetsScopes;
 import com.google.api.services.sheets.v4.model.*;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Service;
 import ru.avitoAnalytics.AvitoAnalyticsBot.models.AvitoItems;
-import ru.avitoAnalytics.AvitoAnalyticsBot.models.StatSummary;
 import ru.avitoAnalytics.AvitoAnalyticsBot.service.GoogleSheetsService;
 
 import java.io.IOException;
@@ -20,8 +18,6 @@ import java.io.InputStream;
 import java.security.GeneralSecurityException;
 import java.time.LocalDate;
 import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Service
@@ -112,11 +108,11 @@ public class GoogleSheetsServiceImpl implements GoogleSheetsService {
                 throw new RuntimeException(e);
             }
         }
-        try {
+        /*try {
             Thread.sleep(60000L);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
-        }
+        }*/
         return itemsId;
     }
 
@@ -153,7 +149,7 @@ public class GoogleSheetsServiceImpl implements GoogleSheetsService {
         Map<String, List<AvitoItems>> itemsRange = new HashMap<>();
         int i = 0;
         for (AvitoItems item : listItems) {
-            int paramForRange = (i * 15) + 2;
+            int paramForRange = (i * 15) + 3;
             String currentItemRange = String.format(range, paramForRange, paramForRange);
             String nextColumn = getNextColumn(sheetsLink, currentItemRange);
             String dopColumn = getDopColumn(nextColumn);
@@ -167,7 +163,7 @@ public class GoogleSheetsServiceImpl implements GoogleSheetsService {
 
     @Override
     public Optional<LocalDate> getOldestDate(String sheetsLink) {
-        String range = "test!D2:D2";
+        String range = "test!D3:D3";
         String sheetsId = parseTokenFromSheetsRef(sheetsLink);
         try {
             ValueRange value = service.spreadsheets().values().get(sheetsId, range).execute();
@@ -273,7 +269,7 @@ public class GoogleSheetsServiceImpl implements GoogleSheetsService {
 
     private String createRange(String nextColumn, String dopColumn) {
         if (nextColumn.equals("C")) {
-            return "test!D%d:JM%d";
+            return "test!D%d:RH%d";
         }
         StringBuilder range = new StringBuilder("test!");
         range.append(nextColumn).append("%d:").append(dopColumn).append("%d");

--- a/src/main/java/ru/avitoAnalytics/AvitoAnalyticsBot/util/SheetsStatUtil.java
+++ b/src/main/java/ru/avitoAnalytics/AvitoAnalyticsBot/util/SheetsStatUtil.java
@@ -1,0 +1,34 @@
+package ru.avitoAnalytics.AvitoAnalyticsBot.util;
+
+import lombok.experimental.UtilityClass;
+import ru.avitoAnalytics.AvitoAnalyticsBot.models.StatSummary;
+
+import java.time.LocalDate;
+import java.time.format.TextStyle;
+import java.util.List;
+import java.util.Locale;
+
+@UtilityClass
+public class SheetsStatUtil {
+
+    public static List<StatSummary> setStatsWeek(LocalDate lastDate) {
+        String templateForStats = "=SUM(OFFSET(INDIRECT(ADDRESS(ROW();COLUMN();));0;-7;1;7))";
+        String templateForCV = "=CELL(\"contents\"; INDIRECT(ADDRESS(ROW()+1;COLUMN();))) / CELL(\"contents\"; INDIRECT(ADDRESS(ROW()-1;COLUMN();)))";
+        String startWeek = lastDate.minusDays(6).toString();
+        return List.of(new StatSummary("Итог недели", startWeek + "-" + lastDate.toString(),
+                templateForStats,
+                templateForCV,
+                templateForStats,
+                templateForStats,
+                templateForStats,
+                templateForStats,
+                templateForStats,
+                templateForStats));
+    }
+
+    public static String getDayOfWeek(LocalDate date) {
+        return date.getDayOfWeek().getDisplayName(TextStyle.SHORT, new Locale("ru"));
+    }
+
+
+}


### PR DESCRIPTION
1) The dates are set:
	- for new announcements - a year in advance
	- for other ads - 30 days in advance 2) Added a utility class for general methods of filling statistics in tables